### PR TITLE
fix: correctly handle user ids which don't fit in 32 bits

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,7 +16,7 @@ Bundler.require(*Rails.groups)
 
 module MobiusBot
   class Application < Rails::Application
-    config.load_defaults 5.1
+    config.load_defaults 5.2
     config.api_only = true
     config.active_job.queue_adapter = :sucker_punch
     config.redis_url = ENV.fetch('REDIS_URL', 'redis://localhost:6379')

--- a/db/migrate/20220608211647_change_user_ids_to_bigint.rb
+++ b/db/migrate/20220608211647_change_user_ids_to_bigint.rb
@@ -1,0 +1,6 @@
+class ChangeUserIdsToBigint < ActiveRecord::Migration[5.2]
+  def change
+    change_column :users, :id, :bigint
+    change_column :users, :telegram_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,13 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_31_115524) do
+ActiveRecord::Schema.define(version: 2022_06_08_211647) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "users", force: :cascade do |t|
-    t.integer "telegram_id"
+    t.bigint "telegram_id"
     t.string "username"
     t.boolean "is_resident", default: false
     t.datetime "created_at", null: false


### PR DESCRIPTION
Since [Bot API 5.5](https://core.telegram.org/bots/api-changelog#december-7-2021) user identifiers no longer fit into 32-bit integer range. This PR updates corresponding DB columns to 64 bit integers.